### PR TITLE
Fix dev dependency config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 
-[dependency-groups]
+[project.optional-dependencies]
 dev = [
     "coverage>=7.8.2",
     "httpx>=0.28.1",


### PR DESCRIPTION
This is to fix:

```sh
(fastapi-tags) fastapi-tags % uv pip install -e ".[dev]"
Resolved 11 packages in 759ms
      Built fastapi-tags @ file:///Users/arg/foss/fastapi-tags
Prepared 1 package in 481ms
Uninstalled 1 package in 0.64ms
Installed 1 package in 1ms
 ~ fastapi-tags==0.4.0 (from file:///Users/arg/foss/fastapi-tags)
warning: The package `fastapi-tags @ file:///Users/arg/foss/fastapi-tags` does not have an extra named `dev`
```