### PR TITLE
Add contributing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+To set this up as a contributor:
+
+1. Fork and git clone this repo
+2. Install it for local development, including the dev dependencies:
+
+```sh
+uv venv
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+```


### PR DESCRIPTION
Explicitly tell contributors to install fastapi-tags in pip editable mode with [dev] dependencies.