### PR TITLE
Add support for SVGs

### DIFF
--- a/fastapi_tags/__init__.py
+++ b/fastapi_tags/__init__.py
@@ -119,3 +119,4 @@ from .tags import (
     Video as Video,
     Wbr as Wbr,
 )
+from . import svg as svg

--- a/fastapi_tags/svg.py
+++ b/fastapi_tags/svg.py
@@ -1,261 +1,253 @@
-from .tags import Tag
+from .tags import CaseTag
 
 
-class SvgTag(Tag):
-    @property
-    def name(self) -> str:
-        if not self._name:
-            return self._name
-        return self._name[0].lower() + self._name[1:]
-
-
-class A(SvgTag):
+class A(CaseTag):
     pass
 
 
-class Animate(SvgTag):
+class Animate(CaseTag):
     pass
 
 
-class AnimateMotion(SvgTag):
+class AnimateMotion(CaseTag):
     pass
 
 
-class AnimateTransform(SvgTag):
+class AnimateTransform(CaseTag):
     pass
 
 
-class Circle(SvgTag):
+class Circle(CaseTag):
     pass
 
 
-class ClipPath(SvgTag):
+class ClipPath(CaseTag):
     pass
 
 
-class Defs(SvgTag):
+class Defs(CaseTag):
     pass
 
 
-class Desc(SvgTag):
+class Desc(CaseTag):
     pass
 
 
-class Ellipse(SvgTag):
+class Ellipse(CaseTag):
     pass
 
 
-class FeBlend(SvgTag):
+class FeBlend(CaseTag):
     pass
 
 
-class FeColorMatrix(SvgTag):
+class FeColorMatrix(CaseTag):
     pass
 
 
-class FeComponentTransfer(SvgTag):
+class FeComponentTransfer(CaseTag):
     pass
 
 
-class FeComposite(SvgTag):
+class FeComposite(CaseTag):
     pass
 
 
-class FeConvolveMatrix(SvgTag):
+class FeConvolveMatrix(CaseTag):
     pass
 
 
-class FeDiffuseLighting(SvgTag):
+class FeDiffuseLighting(CaseTag):
     pass
 
 
-class FeDisplacementMap(SvgTag):
+class FeDisplacementMap(CaseTag):
     pass
 
 
-class FeDistantLight(SvgTag):
+class FeDistantLight(CaseTag):
     pass
 
 
-class FeDropShadow(SvgTag):
+class FeDropShadow(CaseTag):
     pass
 
 
-class FeFlood(SvgTag):
+class FeFlood(CaseTag):
     pass
 
 
-class FeFuncA(SvgTag):
+class FeFuncA(CaseTag):
     pass
 
 
-class FeFuncB(SvgTag):
+class FeFuncB(CaseTag):
     pass
 
 
-class FeFuncG(SvgTag):
+class FeFuncG(CaseTag):
     pass
 
 
-class FeFuncR(SvgTag):
+class FeFuncR(CaseTag):
     pass
 
 
-class FeGaussianBlur(SvgTag):
+class FeGaussianBlur(CaseTag):
     pass
 
 
-class FeImage(SvgTag):
+class FeImage(CaseTag):
     pass
 
 
-class FeMerge(SvgTag):
+class FeMerge(CaseTag):
     pass
 
 
-class FeMergeNode(SvgTag):
+class FeMergeNode(CaseTag):
     pass
 
 
-class FeMorphology(SvgTag):
+class FeMorphology(CaseTag):
     pass
 
 
-class FeOffset(SvgTag):
+class FeOffset(CaseTag):
     pass
 
 
-class FePointLight(SvgTag):
+class FePointLight(CaseTag):
     pass
 
 
-class FeSpecularLighting(SvgTag):
+class FeSpecularLighting(CaseTag):
     pass
 
 
-class FeSpotLight(SvgTag):
+class FeSpotLight(CaseTag):
     pass
 
 
-class FeTile(SvgTag):
+class FeTile(CaseTag):
     pass
 
 
-class FeTurbulence(SvgTag):
+class FeTurbulence(CaseTag):
     pass
 
 
-class Filter(SvgTag):
+class Filter(CaseTag):
     pass
 
 
-class ForeignObject(SvgTag):
+class ForeignObject(CaseTag):
     pass
 
 
-class G(SvgTag):
+class G(CaseTag):
     pass
 
 
-class Image(SvgTag):
+class Image(CaseTag):
     pass
 
 
-class Line(SvgTag):
+class Line(CaseTag):
     pass
 
 
-class LinearGradient(SvgTag):
+class LinearGradient(CaseTag):
     pass
 
 
-class Marker(SvgTag):
+class Marker(CaseTag):
     pass
 
 
-class Mask(SvgTag):
+class Mask(CaseTag):
     pass
 
 
-class Metadata(SvgTag):
+class Metadata(CaseTag):
     pass
 
 
-class Mpath(SvgTag):
+class Mpath(CaseTag):
     pass
 
 
-class Path(SvgTag):
+class Path(CaseTag):
     pass
 
 
-class Pattern(SvgTag):
+class Pattern(CaseTag):
     pass
 
 
-class Polygon(SvgTag):
+class Polygon(CaseTag):
     pass
 
 
-class Polyline(SvgTag):
+class Polyline(CaseTag):
     pass
 
 
-class RadialGradient(SvgTag):
+class RadialGradient(CaseTag):
     pass
 
 
-class Rect(SvgTag):
+class Rect(CaseTag):
     pass
 
 
-class Script(SvgTag):
+class Script(CaseTag):
     pass
 
 
-class Set(SvgTag):
+class Set(CaseTag):
     pass
 
 
-class Stop(SvgTag):
+class Stop(CaseTag):
     pass
 
 
-class Style(SvgTag):
+class Style(CaseTag):
     pass
 
 
-class Svg(SvgTag):
+class Svg(CaseTag):
     pass
 
 
-class Switch(SvgTag):
+class Switch(CaseTag):
     pass
 
 
-class Symbol(SvgTag):
+class Symbol(CaseTag):
     pass
 
 
-class Text(SvgTag):
+class Text(CaseTag):
     pass
 
 
-class TextPath(SvgTag):
+class TextPath(CaseTag):
     pass
 
 
-class Title(SvgTag):
+class Title(CaseTag):
     pass
 
 
-class Tspan(SvgTag):
+class Tspan(CaseTag):
     pass
 
 
-class Use(SvgTag):
+class Use(CaseTag):
     pass
 
 
-class View(SvgTag):
+class View(CaseTag):
     pass

--- a/fastapi_tags/svg.py
+++ b/fastapi_tags/svg.py
@@ -1,0 +1,261 @@
+from .tags import Tag
+
+
+class SvgTag(Tag):
+    @property
+    def name(self) -> str:
+        if not self._name:
+            return self._name
+        return self._name[0].lower() + self._name[1:]
+
+
+class A(SvgTag):
+    pass
+
+
+class Animate(SvgTag):
+    pass
+
+
+class AnimateMotion(SvgTag):
+    pass
+
+
+class AnimateTransform(SvgTag):
+    pass
+
+
+class Circle(SvgTag):
+    pass
+
+
+class ClipPath(SvgTag):
+    pass
+
+
+class Defs(SvgTag):
+    pass
+
+
+class Desc(SvgTag):
+    pass
+
+
+class Ellipse(SvgTag):
+    pass
+
+
+class FeBlend(SvgTag):
+    pass
+
+
+class FeColorMatrix(SvgTag):
+    pass
+
+
+class FeComponentTransfer(SvgTag):
+    pass
+
+
+class FeComposite(SvgTag):
+    pass
+
+
+class FeConvolveMatrix(SvgTag):
+    pass
+
+
+class FeDiffuseLighting(SvgTag):
+    pass
+
+
+class FeDisplacementMap(SvgTag):
+    pass
+
+
+class FeDistantLight(SvgTag):
+    pass
+
+
+class FeDropShadow(SvgTag):
+    pass
+
+
+class FeFlood(SvgTag):
+    pass
+
+
+class FeFuncA(SvgTag):
+    pass
+
+
+class FeFuncB(SvgTag):
+    pass
+
+
+class FeFuncG(SvgTag):
+    pass
+
+
+class FeFuncR(SvgTag):
+    pass
+
+
+class FeGaussianBlur(SvgTag):
+    pass
+
+
+class FeImage(SvgTag):
+    pass
+
+
+class FeMerge(SvgTag):
+    pass
+
+
+class FeMergeNode(SvgTag):
+    pass
+
+
+class FeMorphology(SvgTag):
+    pass
+
+
+class FeOffset(SvgTag):
+    pass
+
+
+class FePointLight(SvgTag):
+    pass
+
+
+class FeSpecularLighting(SvgTag):
+    pass
+
+
+class FeSpotLight(SvgTag):
+    pass
+
+
+class FeTile(SvgTag):
+    pass
+
+
+class FeTurbulence(SvgTag):
+    pass
+
+
+class Filter(SvgTag):
+    pass
+
+
+class ForeignObject(SvgTag):
+    pass
+
+
+class G(SvgTag):
+    pass
+
+
+class Image(SvgTag):
+    pass
+
+
+class Line(SvgTag):
+    pass
+
+
+class LinearGradient(SvgTag):
+    pass
+
+
+class Marker(SvgTag):
+    pass
+
+
+class Mask(SvgTag):
+    pass
+
+
+class Metadata(SvgTag):
+    pass
+
+
+class Mpath(SvgTag):
+    pass
+
+
+class Path(SvgTag):
+    pass
+
+
+class Pattern(SvgTag):
+    pass
+
+
+class Polygon(SvgTag):
+    pass
+
+
+class Polyline(SvgTag):
+    pass
+
+
+class RadialGradient(SvgTag):
+    pass
+
+
+class Rect(SvgTag):
+    pass
+
+
+class Script(SvgTag):
+    pass
+
+
+class Set(SvgTag):
+    pass
+
+
+class Stop(SvgTag):
+    pass
+
+
+class Style(SvgTag):
+    pass
+
+
+class Svg(SvgTag):
+    pass
+
+
+class Switch(SvgTag):
+    pass
+
+
+class Symbol(SvgTag):
+    pass
+
+
+class Text(SvgTag):
+    pass
+
+
+class TextPath(SvgTag):
+    pass
+
+
+class Title(SvgTag):
+    pass
+
+
+class Tspan(SvgTag):
+    pass
+
+
+class Use(SvgTag):
+    pass
+
+
+class View(SvgTag):
+    pass

--- a/fastapi_tags/tags.py
+++ b/fastapi_tags/tags.py
@@ -61,6 +61,16 @@ class Tag:
         return f"<{self.name}{self.attrs}>{self.children}</{self.name}>"
 
 
+class CaseTag(Tag):
+    """This is for case-sensitive tags like those used in SVG generation."""
+
+    @property
+    def name(self) -> str:
+        if not self._name:
+            return self._name
+        return self._name[0].lower() + self._name[1:]
+
+
 # Special tags
 
 

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -1,0 +1,16 @@
+import fastapi_tags.svg as sg
+
+
+def test_atag_no_attrs_no_children():
+    assert sg.A().render() == "<a></a>"
+
+
+def test_cased_tag_no_children():
+    assert sg.AnimateMotion().render() == "<animateMotion></animateMotion>"
+
+
+def test_cased_tags_with_children():
+    assert (
+        sg.AnimateMotion(sg.ClipPath()).render()
+        == "<animateMotion><clipPath></clipPath></animateMotion>"
+    )


### PR DESCRIPTION
Usage:

```python
from fastapi import FastAPI
import fastapi_tags as tg
import fastapi_tags.svg as sg

app = FastAPI()


@app.get("/", response_class=tg.TagResponse)
async def index():
    return tg.Html(
        tg.H1("Hello, world!", style="color: blue;"),
        sg.Svg(
            sg.Circle(cx="100", cy="100", r="50", fill="red"), width="200", height="200"
        ),
    )
```

Items still being considered:

1. Uses a different import path so that for code-completion people writing pages aren't hammered with lots of suggestions for SVG tags
2. Render could be more terse. Example:  `Circle()` without a child renders as `<child></child>` instead of `<child />`