### PR TITLE
Raw html

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,19 @@ async def card():
     <footer>by various contributors</footer>
 </article>
 ```
+
+## Raw HTML Content
+
+For cases where you need to render raw HTML:
+
+```python
+from fastapi_tags import RawHTML
+
+# Render raw HTML content
+raw_content = RawHTML('<strong>Bold text</strong> and <em>italic</em>')
+
+# Note: RawHTML only accepts a single string argument
+# For multiple elements, combine them first:
+html_string = '<p>First</p><p>Second</p>'
+raw = RawHTML(html_string)
+```

--- a/fastapi_tags/__init__.py
+++ b/fastapi_tags/__init__.py
@@ -83,6 +83,7 @@ from .tags import (
     Pre as Pre,
     Progress as Progress,
     Q as Q,
+    RawHTML as RawHTML,
     Rp as Rp,
     Rt as Rt,
     Ruby as Ruby,

--- a/fastapi_tags/tags.py
+++ b/fastapi_tags/tags.py
@@ -85,15 +85,15 @@ class RawHTML(Tag):
 
     Args:
         html_string: A single string containing raw HTML to render
-        
+
     Raises:
         TypeError: If non-string content is provided
         ValueError: If multiple arguments are provided
-    
+
     Example:
         >>> RawHTML('<strong>Bold</strong> text')
         '<strong>Bold</strong> text'
-        
+
         >>> # Use with other tags
         >>> Div(
         ...     P("Safe content"),
@@ -101,24 +101,24 @@ class RawHTML(Tag):
         ...     P("More safe content")
         ... )
     """
-    
+
     def __init__(self, *args, **kwargs):
         """Initialize RawHTML with a single string argument.
-        
+
         Args:
             *args: Should be exactly one string argument
             **kwargs: Ignored (for consistency with Tag interface)
         """
         if len(args) > 1:
             raise ValueError("RawHTML accepts only one string argument")
-        
+
         html_string = args[0] if args else ""
-        
+
         if not isinstance(html_string, str):
             raise TypeError("RawHTML only accepts string content")
-        
+
         super().__init__(html_string)
-    
+
     def render(self) -> str:
         """Render the raw HTML string without escaping."""
         return self._children[0] if self._children else ""

--- a/fastapi_tags/tags.py
+++ b/fastapi_tags/tags.py
@@ -80,6 +80,50 @@ class A(Tag):
     pass
 
 
+class RawHTML(Tag):
+    """Custom tag for rendering raw HTML content without escaping.
+
+    Args:
+        html_string: A single string containing raw HTML to render
+        
+    Raises:
+        TypeError: If non-string content is provided
+        ValueError: If multiple arguments are provided
+    
+    Example:
+        >>> RawHTML('<strong>Bold</strong> text')
+        '<strong>Bold</strong> text'
+        
+        >>> # Use with other tags
+        >>> Div(
+        ...     P("Safe content"),
+        ...     RawHTML('<hr class="divider">'),
+        ...     P("More safe content")
+        ... )
+    """
+    
+    def __init__(self, *args, **kwargs):
+        """Initialize RawHTML with a single string argument.
+        
+        Args:
+            *args: Should be exactly one string argument
+            **kwargs: Ignored (for consistency with Tag interface)
+        """
+        if len(args) > 1:
+            raise ValueError("RawHTML accepts only one string argument")
+        
+        html_string = args[0] if args else ""
+        
+        if not isinstance(html_string, str):
+            raise TypeError("RawHTML only accepts string content")
+        
+        super().__init__(html_string)
+    
+    def render(self) -> str:
+        """Render the raw HTML string without escaping."""
+        return self._children[0] if self._children else ""
+
+
 class Abbr(Tag):
     """Defines an abbreviation or an acronym"""
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -82,3 +82,41 @@ def test_special_attributes():
 
     html = tg.P("HTMX example", hx_post="/get", _id="53").render()
     assert html == '<p hx-post="/get" id="53">HTMX example</p>'
+
+
+def test_raw_html_basic():
+    """Test basic RawHTML rendering without escaping."""
+    raw = tg.RawHTML('<strong>Bold</strong> & <em>italic</em>')
+    assert raw.render() == '<strong>Bold</strong> & <em>italic</em>'
+
+
+def test_raw_html_with_script():
+    """Test that RawHTML does not escape script tags (security risk)."""
+    raw = tg.RawHTML('<script>alert("XSS")</script>')
+    assert raw.render() == '<script>alert("XSS")</script>'
+    # This test documents the security risk
+
+def test_raw_html_invalid_args():
+    """Test that RawHTML raises errors with invalid arguments."""
+    try:
+        tg.RawHTML('first', 'second')
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        assert "RawHTML accepts only one string argument" in str(e)
+
+    try:
+        tg.RawHTML(123)
+        assert False, "Expected TypeError"
+    except TypeError as e:
+        assert "RawHTML only accepts string content" in str(e)
+
+    try:
+        tg.RawHTML(tg.Div("test"))
+        assert False, "Expected TypeError"
+    except TypeError as e:
+        assert "RawHTML only accepts string content" in str(e)
+
+def test_raw_html_ignores_kwargs():
+    """Test that RawHTML ignores keyword arguments."""
+    raw = tg.RawHTML('<div>Test</div>', id="ignored", cls="also-ignored")
+    assert raw.render() == '<div>Test</div>'

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -86,8 +86,8 @@ def test_special_attributes():
 
 def test_raw_html_basic():
     """Test basic RawHTML rendering without escaping."""
-    raw = tg.RawHTML('<strong>Bold</strong> & <em>italic</em>')
-    assert raw.render() == '<strong>Bold</strong> & <em>italic</em>'
+    raw = tg.RawHTML("<strong>Bold</strong> & <em>italic</em>")
+    assert raw.render() == "<strong>Bold</strong> & <em>italic</em>"
 
 
 def test_raw_html_with_script():
@@ -96,10 +96,11 @@ def test_raw_html_with_script():
     assert raw.render() == '<script>alert("XSS")</script>'
     # This test documents the security risk
 
+
 def test_raw_html_invalid_args():
     """Test that RawHTML raises errors with invalid arguments."""
     try:
-        tg.RawHTML('first', 'second')
+        tg.RawHTML("first", "second")
         assert False, "Expected ValueError"
     except ValueError as e:
         assert "RawHTML accepts only one string argument" in str(e)
@@ -116,7 +117,8 @@ def test_raw_html_invalid_args():
     except TypeError as e:
         assert "RawHTML only accepts string content" in str(e)
 
+
 def test_raw_html_ignores_kwargs():
     """Test that RawHTML ignores keyword arguments."""
-    raw = tg.RawHTML('<div>Test</div>', id="ignored", cls="also-ignored")
-    assert raw.render() == '<div>Test</div>'
+    raw = tg.RawHTML("<div>Test</div>", id="ignored", cls="also-ignored")
+    assert raw.render() == "<div>Test</div>"


### PR DESCRIPTION
I added a bit more to it than I originally had because it behaves a bit differently than a normal tag in a few ways, so I though making those differences more explicit would be nice.

The ways it's behavior is different than a normal tag:

- It only takes 1 argument and can't take multiple children (raises error if not).  We could append multiple args together, but I didn't see a clear benefit to doing that and thought it might be confusing.
- The argument must be a string (Raises error if not)
- kwargs are unused even though all other tags make them (documented in doc string, but left in for API consistency)

@pydanny What do you think?  I tried to have it consistent with other tag behaviors for the signature.  Should we do it like this with extra error handling or docs?  After thinking through it maybe it'd be better to have this be a special case where it doesn't have *args **kwargs in the signature at all rather than trying to adhere to other tags signatures?


